### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.http-echo-server
+++ b/Dockerfile.http-echo-server
@@ -1,0 +1,22 @@
+FROM golang:1.21 AS builder
+
+WORKDIR /app
+COPY go.mod .
+COPY main.go .
+RUN go mod download
+RUN go build -o http-echo-server
+
+# Using debian:bookworm as the base image for the runtime stage
+FROM debian:bookworm
+
+# Install ca-certificates, necessary for making HTTPS connections
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+# Copy the binary from the builder stage
+COPY --from=builder /app/http-echo-server /
+
+# Expose the ports the service listens on
+EXPOSE 8080 9090
+
+# Command to run the service
+CMD ["/http-echo-server"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO http-echo-server
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,45 @@
+namespace: http-echo-server
+
+http-echo-server:
+  defines: runnable
+  metadata:
+    name: http-echo-server
+    description: A simple HTTP Echo Server written in Go, listening on two ports.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    http-echo-server:
+      image: env-3061.registry.local/http-echo-server:main-504e5a3
+      build: .
+      dockerfile: Dockerfile.http-echo-server
+  services:
+    http-port-1:
+      description: HTTP server listening on port 1
+      container: http-echo-server
+      port: $port1
+      host-port: $port1
+      publish: true
+      protocol: tcp
+    http-port-2:
+      description: HTTP server listening on port 2
+      container: http-echo-server
+      port: $port2
+      host-port: $port2
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables:
+    port1:
+      env: PORT1
+      type: int
+      value: 8080
+      description: Port 1 for the HTTP server to listen on
+    port2:
+      env: PORT2
+      type: int
+      value: 9090
+      description: Port 2 for the HTTP server to listen on
+
+stack:
+  defines: group
+  members:
+    - http-echo-server/http-echo-server


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration for http-echo-server

This PR introduces the containerization and deployment configuration for the `http-echo-server` application. Below is a summary of the changes and the rationale behind them.

## Containerization

### Dockerfile Creation
A new `Dockerfile` has been created to containerize the `http-echo-server`. The Dockerfile uses a multi-stage build process with `golang:1.21` as the builder image to compile the Go binary and `debian:bookworm` as the runtime image to run the compiled binary. The choice of `debian:bookworm` as the runtime image was made after encountering compatibility issues with GLIBC versions in `debian:buster` and `debian:bullseye`. The `debian:bookworm` image includes the necessary GLIBC versions required by the binary built with `golang:1.21`.

### Service Verification
The containerized service has been tested and verified to be working correctly. It successfully starts listeners on ports `8080` and `9090` and responds to HTTP GET requests with an 'OK' status. The responses include server addresses and client request information, confirming the service's functionality.

## Deployment Configuration

### Service Mapping
The `http-echo-server` is a standalone Go-based HTTP server that does not rely on any third-party services like databases. It listens on two ports (`8080` and `9090`) and echoes back the request details to the client. No additional services were detected within the repository.

### Configuration Analysis
The analysis of the source code and Dockerfile confirmed that the `http-echo-server` service does not require any environment variables for its configuration. It exposes two ports, `8080` and `9090`, for HTTP communication, which are specified in the Dockerfile and the source code. The service does not connect to any external services or other services within the repository.

## Monk.io Configuration

### Configuration Files
The following configuration files have been created to facilitate deployment on monk.io:

- `monk.yaml`: Allows the deployment of the application to monk.io.
- `MANIFEST`: Lists the monk.io YAML files that should be deployed to monk.io.

### Conclusion
The containerization and deployment configuration for the `http-echo-server` are now complete. The service is ready to be deployed and run in a containerized environment using the provided Dockerfile and monk.io configuration files.

---

Please review the changes and provide feedback or approval for merging this PR.