### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.http-echo-server
+++ b/Dockerfile.http-echo-server
@@ -1,0 +1,14 @@
+FROM golang:1.21 AS builder
+
+WORKDIR /app
+COPY go.mod .
+COPY main.go .
+RUN go mod download
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o http-echo-server .
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=builder /app/http-echo-server .
+EXPOSE 8080 9090
+CMD ["./http-echo-server"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO http-echo-server
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,35 @@
+namespace: http-echo-server
+
+http-echo-server:
+  defines: runnable
+  metadata:
+    name: http-echo-server
+    description: A simple HTTP echo server written in Go.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    http-echo-server:
+      image: env-2209.registry.local/http-echo-server:main-504e5a3
+      build: .
+      dockerfile: Dockerfile.http-echo-server
+  services:
+    http-port-1:
+      description: HTTP server listening port
+      container: http-echo-server
+      port: 8080
+      host-port: 8080
+      publish: true
+      protocol: tcp
+    http-port-2:
+      description: HTTP server listening port
+      container: http-echo-server
+      port: 9090
+      host-port: 9090
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - http-echo-server/http-echo-server


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration for HTTP Echo Server

## Dockerfile Creation and Service Configuration

- I created a Dockerfile for the HTTP echo server, which is a standalone Go application that listens on ports 8080 and 9090.
- The Dockerfile is configured with a multi-stage build process:
  - The first stage uses a Golang base image to compile the binary.
  - The second stage copies the compiled binary into a smaller Alpine image.
- The Dockerfile exposes ports 8080 and 9090 and sets the server binary as the container's entry point.
- The HTTP echo server does not require any third-party services or dependencies beyond the Go standard library.

## Monk.io Configuration

- Added `monk.yaml` to define the Monk.io deployment configuration.
- Included a `MANIFEST` file to list all files containing Monk configurations.
- The `http-echo-server` service uses command-line flags `port1` and `port2` to set the listening ports, with default values of 8080 and 9090.
- No environment variables are used for configuration, and the ports are hard-coded in the Go source file `main.go`.

## Instructions for Continuation

- The PR is ready to be merged. Upon merging, the application will be re-deployed on each subsequent push.
- The service is functioning as expected and can be deployed using the provided Dockerfile and Monk.io configuration.
- No further action is required unless changes to the default ports or additional configurations are needed in the future.

## Conclusion

The HTTP echo server is containerized successfully, and the deployment configuration is set up correctly. The server is operational and responds to HTTP GET requests on the specified ports without any issues. The process is complete, and the application is ready for deployment.