### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.http-echo-server
+++ b/Dockerfile.http-echo-server
@@ -1,0 +1,14 @@
+FROM golang:1.18 AS builder
+
+WORKDIR /app
+COPY go.mod .
+COPY main.go .
+RUN go mod download
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o http-echo-server .
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=builder /app/http-echo-server .
+EXPOSE 8080 9090
+CMD ["./http-echo-server"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO http-echo-server
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,35 @@
+namespace: http-echo-server
+
+http-echo-server:
+  defines: runnable
+  metadata:
+    name: http-echo-server
+    description: A simple HTTP echo server that listens on two ports.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    http-echo-server:
+      image: env-3901.registry.local/http-echo-server:main-504e5a3
+      build: .
+      dockerfile: Dockerfile.http-echo-server
+  services:
+    http-port-8080:
+      description: Default HTTP port for the echo server
+      container: http-echo-server
+      port: 8080
+      host-port: 8080
+      publish: true
+      protocol: tcp
+    http-port-9090:
+      description: Secondary HTTP port for the echo server
+      container: http-echo-server
+      port: 9090
+      host-port: 9090
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - http-echo-server/http-echo-server


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration for HTTP Echo Server

## Containerization
- I have created a Dockerfile named `Dockerfile.http-echo-server` for the HTTP Echo Server application.
- The Dockerfile is set up with a multi-stage build process that compiles the Go application and then copies the binary into a lightweight Alpine container.
- It exposes ports 8080 and 9090, which are the default ports the application listens on.
- The application is confirmed to be self-contained and does not require any external services like databases.

## Deployment Configuration
- Added a `monk.yaml` file to define the Monk.io deployment configuration.
- Included a `MANIFEST` file that lists all files containing Monk configurations.
- The configuration does not specify any environment variables as the application does not require any and uses command-line flags to set the ports.
- The service is designed to run in isolation and includes its own checker to simulate client requests.

## Instructions for Continuation
- The PR is ready to be merged. Upon merging, the application will be re-deployed on each subsequent push.
- No further actions are required as the service is functioning properly and the containerization along with deployment configuration is complete.

## Summary
- The HTTP Echo Server is now containerized with a Dockerfile that aligns with the application's requirements.
- Deployment configuration is provided through Monk.io files, ensuring easy deployment and scaling.
- The application is ready for deployment without the need for additional environment variables or external service connections.