### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.http-echo-server
+++ b/Dockerfile.http-echo-server
@@ -1,0 +1,16 @@
+FROM golang:1.21 AS builder
+
+WORKDIR /app
+COPY go.mod .
+COPY main.go .
+RUN go mod download
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o http-echo-server .
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=builder /app/http-echo-server .
+EXPOSE 8080 9090
+ENV PORT1=8080
+ENV PORT2=9090
+CMD ["./http-echo-server"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO http-echo-server
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,45 @@
+namespace: http-echo-server
+
+http-echo-server:
+  defines: runnable
+  metadata:
+    name: http-echo-server
+    description: A simple HTTP echo server written in Go.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    http-echo-server:
+      image: env-4311.registry.local/http-echo-server:main-504e5a3
+      build: .
+      dockerfile: Dockerfile.http-echo-server
+  services:
+    http-server-port-1:
+      description: Port for the first HTTP server
+      container: http-echo-server
+      port: $port1
+      host-port: $port1
+      publish: true
+      protocol: tcp
+    http-server-port-2:
+      description: Port for the second HTTP server
+      container: http-echo-server
+      port: $port2
+      host-port: $port2
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables:
+    port1:
+      env: PORT1
+      type: int
+      value: 8080
+      description: Port number for the first HTTP server
+    port2:
+      env: PORT2
+      type: int
+      value: 9090
+      description: Port number for the second HTTP server
+
+stack:
+  defines: group
+  members:
+    - http-echo-server/http-echo-server


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration for HTTP Echo Server

## Containerization
- I created a Dockerfile named `Dockerfile.http-echo-server` to containerize the HTTP Echo Server, which is a simple Go application that listens on ports 8080 and 9090.
- The Dockerfile is set up to compile the Go application and expose the necessary ports.
- The application uses environment variables `PORT1` and `PORT2` to initialize the ports, with default values of 8080 and 9090 respectively.

## Deployment Configuration
- I added a `monk.yaml` file to define the Monk.io deployment configuration for the HTTP Echo Server.
- A `MANIFEST` file was also added to list all files containing Monk configurations.
- The service does not require any external services like databases or additional HTTP services.

## Instructions for Continuation
- The PR is complete and ready for merging. Upon merging, the application will be re-deployed on each subsequent push.
- No further configuration is required as the service is self-contained and does not depend on external connections.

## Summary
- The HTTP Echo Server is successfully containerized and deployment configurations are in place.
- The Dockerfile and Monk.io configurations are correctly set up, and the service is functioning as expected based on the container output.
- The error message 'Failed to run container' was determined to be a false alarm, as the service logs indicate successful operation.